### PR TITLE
Update ClosedCube_HDC1080.cpp

### DIFF
--- a/src/ClosedCube_HDC1080.cpp
+++ b/src/ClosedCube_HDC1080.cpp
@@ -40,7 +40,10 @@ ClosedCube_HDC1080::ClosedCube_HDC1080()
 void ClosedCube_HDC1080::begin(uint8_t address) {
 	_address = address;
 	Wire.begin();
-
+	HDC1080_Registers reg;
+	reg.SoftwareReset = 1;
+	writeRegister(reg);
+	delay(200);
 	setResolution(HDC1080_RESOLUTION_14BIT, HDC1080_RESOLUTION_14BIT);
 }
 


### PR DESCRIPTION
Added a software reset to the begin() function. It allows reseting the sensor in case it hangs, by calling begin() again. With the original implementation the only option would be to power cycle it.